### PR TITLE
use the checkout session id to customize the success and cancel pages

### DIFF
--- a/public/cancel.html
+++ b/public/cancel.html
@@ -7,6 +7,19 @@
 <body>
   <section>
     <p>Forgot to add something to your cart? Shop around then come back to pay!</p>
+    <form id="checkout-form" action="/create-checkout-session" method="POST">
+      <button type="submit" id="checkout-button">Return to Checkout</button>
+    </form>
   </section>
+  <script>
+    document.addEventListener('DOMContentLoaded', async () => {
+      var urlParams = new URLSearchParams(window.location.search);
+      var sessionId = urlParams.get('session_id');
+      let form = document.getElementById("checkout-form");
+      if (sessionId) {
+        form.action=`return-to-checkout?session_id=${sessionId}`;
+      }
+  });
+  </script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -78,3 +78,20 @@ button {
 button:hover {
   opacity: 0.8;
 }
+
+.order-info {
+  height: 600px;
+}
+
+.order-info ul {
+  list-style-type: none;
+}
+
+.order-info p {
+  display: inline;
+}
+
+.order-info h1{
+  color: #242d60;
+  text-align: center;
+}

--- a/public/success.html
+++ b/public/success.html
@@ -3,9 +3,19 @@
 <head>
   <title>Thanks for your order!</title>
   <link rel="stylesheet" href="style.css">
+  <script src="success.js" defer></script>
 </head>
 <body>
-  <section>
+  <section class="order-info">
+    <h1>Thank you for your order!</h1>
+    <ul>
+      <li>Name:<span id="customer_name"></span> </li>
+      <li>Email: <span id="customer_email"></span></li>
+    </ul>
+    <ul>
+      <li>Order Total: <span id="order_total"></span></li>
+      <li>Payment Status: <span id="payment_status"></span></li>
+    </ul>
     <p>
       We appreciate your business! If you have any questions, please email
       <a href="mailto:orders@example.com">orders@example.com</a>.

--- a/public/success.js
+++ b/public/success.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  let urlParams = new URLSearchParams(window.location.search);
+  let sessionId = urlParams.get('session_id');
+
+  if (sessionId) {
+    const {customer, session} = await fetch(`order-info?session_id=${sessionId}`)
+      .then((r) => r.json());
+
+    setText("customer_name", customer.name);
+    setText("customer_email", customer.email);
+    setText("payment_status", session.payment_status);
+
+    let currencyFmt = Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: `${session.currency}`,
+    });
+
+    setText("order_total", `${currencyFmt.format(session.amount_total/100)}`);
+  }
+});
+
+const setText = (elementId, text) => {
+  const element = document.querySelector(`#${elementId}`);
+  element.innerHTML = text;
+}

--- a/server.rb
+++ b/server.rb
@@ -31,9 +31,23 @@ post '/create-checkout-session' do
       quantity: 1,
     }],
     mode: 'payment',
-      success_url: YOUR_DOMAIN + '/success.html',
-      cancel_url: YOUR_DOMAIN + '/cancel.html',
+    success_url: YOUR_DOMAIN + '/success.html?session_id={CHECKOUT_SESSION_ID}',
+    cancel_url: YOUR_DOMAIN + '/cancel.html?session_id={CHECKOUT_SESSION_ID}',
   })
+  redirect session.url, 303
+end
+
+get '/order-info' do
+  session = Stripe::Checkout::Session.retrieve(params[:session_id])
+  customer = Stripe::Customer.retrieve(session.customer)
+  {
+    session: session,
+    customer: customer
+  }.to_json
+end
+
+post '/return-to-checkout' do
+  session = Stripe::Checkout::Session.retrieve(params[:session_id])
   redirect session.url, 303
 end
 


### PR DESCRIPTION
The PR corresponds to the Checkout Foundations 101 video [Build a custom order confirmation page with Checkout](https://www.youtube.com/watch?v=nVvDr6MyEXE).  We use the Checkout session id to retrieve order information after the customer has completed their payment and display that information on our success.html page.  We also add support for returning the customer to their Checkout session from the cancel page. 