### PR TITLE
Recover abandoned carts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ You can see the code shown in each 101 episode by video by viewing the correspon
 3. [Build notifications into Checkout](https://www.youtube.com/watch?v=EaX444Fe2Tk): Add a webhook handler to your Checkout integration so you know when you've gotten paid and can fulfill the order.  [PR](https://github.com/stripe-samples/checkout-foundations-ruby/pull/1)
 4. [Build a customer order confirmation page with Checkout](https://www.youtube.com/watch?v=COeMEHKbECw): Use the Checkout Session ID to look up order information after the customer has completed their purchase to display on the success page.  Allow your customers to return to their Checkout session from the cancel page. [PR](https://github.com/stripe-samples/checkout-foundations-ruby/pull/2)
 5. Add support for adjustable quantities: Let your customer adjust their order during Checkout.  Display the total price and quantities for each line item purchased on the success page.  [PR](https://github.com/stripe-samples/checkout-foundations-ruby/pull/3)
+6. Recover abandoned carts: Configure Checkout to generate a new session when the original session is abandoned by the customer and expires.  Collect consent to send promotional emails and listen for session expired events to know when to reach out to encourage a customer to complete their purchase. [PR](https://github.com/stripe-samples/checkout-foundations-ruby/pull/4)
 
 
 ## Get support


### PR DESCRIPTION
Add a recovery flow for abandoned carts, i.e. Checkout sessions that expire before the customer completes their purchase. This flow has a few pieces: 

- Collect consent from the customer to receive promotional emails: Within our Checkout Session create call, we need to configure Checkout to collect consent
- Configure recovery options: Within our Checkout session create call we'll add the `after_expiration` configuration options so that Checkout will generate a recovery URL we can send to customers.  We'll also add support for promotional codes to that session so that we can use a discount to incentive our customers to complete their purchase 
- Listen for `checkout.session.expired` events: when we receive one of these we'll look at whether we have consent from the customer to email them and if so, we'll send them an email with the recovery url from the session. 
- Other enhancements: We reduced our expiration time on the session so we know earlier on that the customer has abandoned their cart.  We also started tracking the `recoved_from` attribute on the session when we get a `checkout.session.completed` event, this can help us track conversion from our email outreach. 